### PR TITLE
requirements.txt: oauth lib from deprecated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 thrift
-oauth2
+oauthlib


### PR DESCRIPTION
Geeknote works with that.

For the context see https://github.com/gentoo/guru/commit/bebb60ef842bdfde41aa273cf808adbbc82bd75c#commitcomment-141378326